### PR TITLE
team(charity-fundraiser): add new team

### DIFF
--- a/assets/configs/teams.json
+++ b/assets/configs/teams.json
@@ -15,5 +15,20 @@
       {"name": "name or alias", "avatarUrl": "./assets/images/default-avatar.webp", "url": "someUrl"},
       {"name": "name or alias", "avatarUrl": "./assets/images/default-avatar.webp", "url": "someUrl"}
     ]
+  },
+  {
+    "name": "Help For Ukraine WebDev Team",
+    "description": "Today I wanted to put my war-related NFTs up for auction in a way the money would automatically be transferred to a charity organisation... And turned out there is no such service on the web! How is that possible?! Everybody just trusts that their donates are then kindly passed by the influencer to the charity. What we'd accomplish with this project is actually a large-scale service domain to help people organise unconventional Fundraising - such that you can buy whatever but the money go to the Fundraiser if the owner agrees so. And the domain could be then maintained by us as the stakeholders or sold as a gigantic startup. I have everything designed and thought throuh, though I suppose throughout a discussion, some conceptual issues may come to light. And I have the will to make that happen, as I'm also a NFT artist and my thoughts often drift towards the market and coverage.",
+    "lookingFor": "frontend developer, backend developer, software architect, cloud solution architect, software developer",
+    "technologies": ["javascript", "to be decided (whatever fits best, could be react, next.js)"],
+    "contact": {
+      "discord": "discord.chanel.url",
+      "messanger": "messanger.team.url",
+      "telegram": "telegram.team.url",
+      "mail": "mail.team.url"
+    },
+    "members": [
+      {"name": "Adam Pylański", "avatarUrl": "./assets/images/default-avatar.webp", "url": "someUrl"}
+    ]
   }
 ]


### PR DESCRIPTION
The Russian aggression must be met with rapid answer. The charity organisations need funding, Ukraine suffers. Yes, people donate money already, but donating in general could be made fancier. NFT (and all other kinds of art or products too) is being sold anyways despite the conflict. Apparently there is no website of this sort yet on the market. It would be a great way for junior or mid developers to include a great global-scale initiative in their portfolio. And each team member would be of course a stakeholder once the start-up project is up and working. Come, join and lets do it! And also we could then use it, or the ideas or the knowledge for the upcoming Google Solutions Challenge, hitting multiple critical points out of the 17.